### PR TITLE
Bug/fixes unlabeled done tickets

### DIFF
--- a/lib/trello-changelog/printers.rb
+++ b/lib/trello-changelog/printers.rb
@@ -36,11 +36,8 @@ class TrelloChangelog
   end
 
   def build_unlabeled
-    @unlabeled_done_tickets = done_tickets
-
-    @config[:labels].each do |label|
-      @unlabeled_done_tickets.select! { |ticket| !ticket.card_labels.find{ |card_label| card_label['name'] == label} }
-    end
+    # We only list the cards that have none of the configured labels
+    @unlabeled_done_tickets = done_tickets.select { |ticket| (ticket.labels.map(&:name) & @config[:labels]).empty? }
 
     @output << "\n## Other\n\n"
     @unlabeled_done_tickets.each do |ticket|

--- a/trello-changelog.gemspec
+++ b/trello-changelog.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'trello-changelog'
-  spec.version = '1.0.1'
+  spec.version = '1.0.2'
   spec.date = '2015-02-19'
   spec.summary = 'Changelog for Trello'
   spec.description	= 'Changelog for Trello'


### PR DESCRIPTION
Fixes issue where we would list all tickets in the 'Other' section instead of only the tickets that none of the configured labels assigned.